### PR TITLE
Update `rand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-rand = "0.7"
+rand = "0.8"
 tempfile = "3"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Hi there!

The latest `tempfile` release bumps the `rand` dependency to the 0.8* series. Updating `tempfile-fast` to match would help keep things tidy. :wink: 

`cargo test`, `cargo clippy`, and `cargo build` all seem to be OK with the simple manifest change.