### PR TITLE
Support async tempfiles and async traits via an `async` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,14 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
+async-fs = { version = "2.1.1", optional = true }
+async-global-executor = { version = "2.4.1", optional = true }
+futures-io = { version = "0.3.30", optional = true }
 rand = "0.8"
 tempfile = "3.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.34"
+
+[features]
+async = ["dep:async-fs", "dep:async-global-executor", "dep:futures-io"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 
 [dependencies]
 rand = "0.8"
-tempfile = "3"
+tempfile = "3.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.34"

--- a/src/persistable.rs
+++ b/src/persistable.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::fs;
 use std::io;
+use std::io::BufRead;
 use std::io::Read;
 use std::io::Seek;
 use std::io::SeekFrom;
@@ -117,6 +118,16 @@ impl<F> fmt::Debug for PersistableTempFile<F> {
 impl<F: Read> Read for PersistableTempFile<F> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.as_mut().read(buf)
+    }
+}
+
+impl<F: BufRead> BufRead for PersistableTempFile<F> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        self.as_mut().fill_buf()
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.as_mut().consume(amt)
     }
 }
 


### PR DESCRIPTION
Add an `async` feature flag to gate the additional dependency. When set,
implement the async versions of `Read`, `BufRead`, `Write`, and `Seek`, and add
an `async_new_in` constructor to create an tempfile around an async `File`.

To support this, make `PersistentTempFile` generic on the inner file type.

This requires the generic `NamedTempFile` support in `tempfile` 3.4.

Introduce a new `make_in` constructor that allows creating a temporary
file with any arbitrary type given a function that turns `File` into
that type.